### PR TITLE
Removed trailing space from the name before it is inserted.

### DIFF
--- a/src/scripts/nameInserter.js
+++ b/src/scripts/nameInserter.js
@@ -90,12 +90,12 @@
 
     function pasteNameFullButton() {
         const tweetTextarea = document.querySelector(TWITTER_SELECTOR.TEST_ID_TWEET_TEXTAREA);
-        pasteName(`${getFirstName()} `, tweetTextarea);
+        pasteName(`${getFirstName()}`, tweetTextarea);
     }
 
     function pasteNameShortButton() {
         const dmTextInput = document.querySelector(TWITTER_SELECTOR.TEST_ID_DM_COMPOSER_TEXT_INPUT);
-        pasteName(`${getFirstName()} `, dmTextInput);
+        pasteName(`${getFirstName()}`, dmTextInput);
     }
 
     function pasteName(name, destination) {


### PR DESCRIPTION
It would be nice if you could trim the space after the name.

Here's why - Now, when I click, I have to go back to delete the space as I use a comma or full stop or question mark after the name.